### PR TITLE
Fix images report

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@fastify/static": "^9.1.3",
     "fastify": "^5.7.4"
   }
 }

--- a/server.js
+++ b/server.js
@@ -2,11 +2,18 @@ import Fastify from "fastify";
 import fs from "fs";
 import path from "path";
 import { spawn } from "child_process";
+import fastifyStatic from "@fastify/static";
 
 const fastify = Fastify({ logger: true });
 
 // Absolute path of the report
 const reportPath = path.join(process.cwd(), "playwright-report", "index.html");
+
+// Register static files from the report folder
+await fastify.register(fastifyStatic, {
+  root: path.join(process.cwd(), "playwright-report"),
+  prefix: "/",
+});
 
 // Whitelist of allowed scripts (We use this in Windows when we can't find the npx)
 const scripts = {
@@ -25,19 +32,17 @@ const scriptsV2 = {
 };
 
 fastify.get("/status", async (request, reply) => {
-    return { message: "La API responde correctamente" };
+  return { message: "La API responde correctamente" };
 });
 
 fastify.get("/report", async (request, reply) => {
-  try {
-    const html = fs.readFileSync(reportPath, "utf-8");
+  const reportPath = path.join(process.cwd(), "playwright-report", "index.html");
 
-    reply
-      .type("text/html")
-      .send(html);
-  } catch (error) {
-    reply.code(404).send({ error: "No se encontró el reporte" });
+  if (!fs.existsSync(reportPath)) {
+    return reply.code(404).send({ message: "No existe el reporte" });
   }
+
+  return reply.sendFile("index.html");
 });
 
 fastify.post("/run-script", async (request, reply) => {
@@ -89,6 +94,5 @@ fastify.delete("/report", async (request, reply) => {
     });
   }
 });
-
 
 fastify.listen({ port: 3122, host: "0.0.0.0" }); //The host must be changed to the one that the machine we are running on has.


### PR DESCRIPTION
Fix so that the report displays images and attachments, allowing the GET /report command to be viewed correctly.